### PR TITLE
Allow fail-fast of the key-uri lookup

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
@@ -278,13 +278,7 @@ public class ResourceServerTokenServicesConfiguration {
 			JwtAccessTokenConverter converter = new JwtAccessTokenConverter();
 			String keyValue = this.resource.getJwt().getKeyValue();
 			if (!StringUtils.hasText(keyValue)) {
-				try {
-					keyValue = getKeyFromServer();
-				}
-				catch (ResourceAccessException ex) {
-					logger.warn("Failed to fetch token key (you may need to refresh "
-							+ "when the auth server is back)");
-				}
+				keyValue = getKeyFromServer();
 			}
 			if (StringUtils.hasText(keyValue) && !keyValue.startsWith("-----BEGIN")) {
 				converter.setSigningKey(keyValue);


### PR DESCRIPTION
Since the public key should be retrieved from a highly available authorisation server, it makes no sense to leave the resource server in an unusable state when something does go wrong.

Please see #734